### PR TITLE
add and delete dashboard observe changes

### DIFF
--- a/app/src/main/java/org/hisp/dhis/android/dashboard/ui/adapters/DashboardAdapter.java
+++ b/app/src/main/java/org/hisp/dhis/android/dashboard/ui/adapters/DashboardAdapter.java
@@ -89,4 +89,15 @@ public class DashboardAdapter extends FragmentPagerAdapter {
             notifyDataSetChanged();
         }
     }
+
+    public int indexOfDashboard(String dashboardName) {
+        int i;
+        for (i = 0; i < mDashboards.size(); i++) {
+            if (mDashboards.get(i).getName().equals(dashboardName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
 }

--- a/app/src/main/java/org/hisp/dhis/android/dashboard/ui/events/DataEvent.java
+++ b/app/src/main/java/org/hisp/dhis/android/dashboard/ui/events/DataEvent.java
@@ -1,0 +1,26 @@
+package org.hisp.dhis.android.dashboard.ui.events;
+
+/**
+ * Created by arazabishov on 7/27/15.
+ */
+public final class DataEvent {
+    private DataEventType mDataEventType;
+    private String mPassDashboardName;
+
+    public DataEvent(String name, DataEventType type) {
+        mPassDashboardName = name;
+        mDataEventType = type;
+    }
+
+    public enum DataEventType {
+        ADDED, DELETED
+    }
+
+    public DataEventType getmDataEventType() {
+        return mDataEventType;
+    }
+
+    public String getmPassDashboardName() {
+        return mPassDashboardName;
+    }
+}

--- a/app/src/main/java/org/hisp/dhis/android/dashboard/ui/fragments/dashboard/DashboardAddFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/dashboard/ui/fragments/dashboard/DashboardAddFragment.java
@@ -41,6 +41,7 @@ import android.widget.TextView;
 import org.hisp.dhis.android.dashboard.R;
 import org.hisp.dhis.android.dashboard.api.models.Dashboard;
 import org.hisp.dhis.android.dashboard.api.utils.EventBusProvider;
+import org.hisp.dhis.android.dashboard.ui.events.DataEvent;
 import org.hisp.dhis.android.dashboard.ui.events.UiEvent;
 import org.hisp.dhis.android.dashboard.ui.fragments.BaseDialogFragment;
 
@@ -92,6 +93,7 @@ public final class DashboardAddFragment extends BaseDialogFragment {
             }
 
             EventBusProvider.post(new UiEvent(UiEvent.UiEventType.SYNC_DASHBOARDS));
+            EventBusProvider.post(new DataEvent(newDashboard.getName(), DataEvent.DataEventType.ADDED));
         }
         dismiss();
     }

--- a/app/src/main/java/org/hisp/dhis/android/dashboard/ui/fragments/dashboard/DashboardManageFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/dashboard/ui/fragments/dashboard/DashboardManageFragment.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.android.dashboard.R;
 import org.hisp.dhis.android.dashboard.api.models.Dashboard;
 import org.hisp.dhis.android.dashboard.api.models.Dashboard$Table;
 import org.hisp.dhis.android.dashboard.api.utils.EventBusProvider;
+import org.hisp.dhis.android.dashboard.ui.events.DataEvent;
 import org.hisp.dhis.android.dashboard.ui.events.UiEvent;
 import org.hisp.dhis.android.dashboard.ui.fragments.BaseDialogFragment;
 
@@ -151,6 +152,7 @@ public final class DashboardManageFragment extends BaseDialogFragment {
                     getDhisService().syncDashboards();
                     EventBusProvider.post(new UiEvent(UiEvent.UiEventType.SYNC_DASHBOARDS));
                 }
+                EventBusProvider.post(new DataEvent(mDashboard.getName(), DataEvent.DataEventType.DELETED));
             }
             case R.id.close_dialog_button: {
                 dismiss();


### PR DESCRIPTION
ViewPager observe changes now on adding and deleting dashboards.
FragmentStatePageAdapter implemented.
Smooth scroll to the added or removed dashboard.
onLoadFinished in DashboardViewPagerFragment is called twice and it is necessary to be called twice, first when saved dashboard locally and second when synced from server. But reflecting added or removed dashboard is called once only, the second time it just updates the data in DashboardAdapter.
